### PR TITLE
add node-sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "levelup": "^1.3.1",
     "lodash": "^4.0.1",
     "mkdirp": "^0.5.1",
+    "node-sass": "^3.4.2",
     "nodemon": "^1.8.1",
     "react": "^0.14.6",
     "react-dom": "^0.14.6",


### PR DESCRIPTION
to fix failing `npm start` command when the user doesn't have node-sass globally installed.